### PR TITLE
Fehlendes " in Zeile 565 der de-DE.ini (administrator)

### DIFF
--- a/administrator/language/de-DE/de-DE.ini
+++ b/administrator/language/de-DE/de-DE.ini
@@ -562,7 +562,7 @@ JGRID_HEADING_LANGUAGE_DESC="Sprache absteigend"
 JGRID_HEADING_MENU_ITEM_TYPE="Menütyp"
 JGRID_HEADING_ORDERING="Reihenfolge"
 JGRID_HEADING_ORDERING_ASC="Reihenfolge aufsteigend"
-JGRID_HEADING_ORDERING_DESC="Reihenfolge absteigend
+JGRID_HEADING_ORDERING_DESC="Reihenfolge absteigend"
 
 JHELP_COMPONENTS_ARTICLE_MANAGER_OPTIONS="Components_Article_Manager_Options"
 JHELP_COMPONENTS_BANNER_MANAGER_OPTIONS="Components_Banner_Manager_Options"


### PR DESCRIPTION
Tracker: #486
http://www.joomla-bugs.de/forum/index.php?topic=486.0
