### PR TITLE
Fehlender Sprachschlüssel JHELP_ADMIN_USER_PROFILE_EDIT

### DIFF
--- a/administrator/language/de-DE/de-DE.ini
+++ b/administrator/language/de-DE/de-DE.ini
@@ -566,6 +566,7 @@ JGRID_HEADING_ORDERING="Reihenfolge"
 JGRID_HEADING_ORDERING_ASC="Reihenfolge aufsteigend"
 JGRID_HEADING_ORDERING_DESC="Reihenfolge absteigend"
 
+JHELP_ADMIN_USER_PROFILE_EDIT="Site_My_Profile"
 JHELP_COMPONENTS_BANNERS_BANNERS_EDIT="Components_Banners_Banners_Edit"
 JHELP_COMPONENTS_BANNERS_BANNERS="Components_Banners_Banners"
 JHELP_COMPONENTS_BANNERS_CATEGORIES="Components_Banners_Categories"


### PR DESCRIPTION
Fehlender Sprachschlüssel JHELP_ADMIN_USER_PROFILE_EDIT siehe: https://github.com/joomla/joomla-cms/pull/3485
