### PR TITLE
Verbessern der Installationsprüfungsberscheibung

### DIFF
--- a/installation/language/de-DE/de-DE.ini
+++ b/installation/language/de-DE/de-DE.ini
@@ -20,7 +20,7 @@ INSTL_WARNJSON="Zur Joomla!-Installation ist ein aktives JSON in der PHP-Umgebun
 
 ; Preinstall view
 INSTL_PRECHECK_TITLE="Installationsprüfung"
-INSTL_PRECHECK_DESC="Sollte nur eins der Einträge rechts vom Server nicht unterstützt werden, mit einem &bdquo;<strong class="_QQ_"red"_QQ_">Nein</strong>&ldquo; gekennzeichnet, dann sollten die Einstellungen auf dem Server angepasst werden.<br />Joomla! kann nicht installiert werden, wenn die unten aufgeführten Systemvoraussetzungen nicht erfüllt sind."
+INSTL_PRECHECK_DESC="Sollte nur eins der Einträge rechts vom Server nicht unterstützt werden, mit einem &bdquo;<strong class="_QQ_"label label-important"_QQ_">Nein</strong>&ldquo; gekennzeichnet, dann sollten die Einstellungen auf dem Server angepasst werden.<br />Joomla! kann nicht installiert werden, wenn die unten aufgeführten Systemvoraussetzungen nicht erfüllt sind."
 INSTL_PRECHECK_RECOMMENDED_SETTINGS_TITLE="Empfohlene Einstellungen:"
 INSTL_PRECHECK_RECOMMENDED_SETTINGS_DESC="Diese Einstellungen werden für PHP empfohlen, um eine gute Kompatibilität mit Joomla! zu gewährleisten.<br />Jedoch kann Joomla! hier mit Einschränkungen in den Empfehlungen trotzdem funktionieren."
 INSTL_PRECHECK_DIRECTIVE="Funktionen"


### PR DESCRIPTION
Derzeit wird sie zwar im Core nicht angezeigt aber ich habe hier:
https://github.com/joomla/joomla-cms/pull/3742

eine PR geschrieben welches diese Beschreibung wieder einblendet.

Da es im "neuen" installer aber keine "red" Klasse gibt schlage ich vor "label label-important" zu nutzen. So wird das "Nein" in der Beschreibung genauso angezeigt wie ein "Nein" in der Installationsprüfung.

Hier ein Bild nach dem oben genannten Patch:
![new_pre_installation](https://cloud.githubusercontent.com/assets/2596554/3211250/5a387022-ef0b-11e3-8a72-24b01ae059d9.JPG)
