### PR TITLE
[3.4] Kleiner neuer String bei den Nachinstallationshinweisen

### DIFF
--- a/administrator/language/de-DE/de-DE.com_postinstall.ini
+++ b/administrator/language/de-DE/de-DE.com_postinstall.ini
@@ -13,6 +13,7 @@ COM_POSTINSTALL_LBL_NOMESSAGES_DESC="Es wurden bereits alle Hinweise für die ak
 COM_POSTINSTALL_LBL_NOMESSAGES_TITLE="Keine Hinweise"
 COM_POSTINSTALL_LBL_RELEASENEWS="Veröffentlichungsnachrichten (von Joomla.org)"
 COM_POSTINSTALL_LBL_SINCEVERSION="Seit Version: %s"
+COM_POSTINSTALL_MESSAGES_FOR="Zeige die Nachinstallationshinweise für"
 COM_POSTINSTALL_MESSAGES_TITLE="Nachinstallationshinweise für %s"
 COM_POSTINSTALL_TITLE_JOOMLA="Joomla!"
 COM_POSTINSTALL_XML_DESCRIPTION="Zeigt Nachinstallations- und Nachaktualisierungshinweise für Joomla! und seine Erweiterungen an."


### PR DESCRIPTION
siehe: https://github.com/joomla/joomla-cms/commit/8fce93a3a9ccf35a863e7bac2c185b9b2921da81