### PR TITLE
[3.4.2] make a proper string to display the PHP Version check

### DIFF
--- a/installation/language/de-DE/de-DE.ini
+++ b/installation/language/de-DE/de-DE.ini
@@ -251,6 +251,7 @@ INSTL_NOTICEYOUCANSTILLINSTALL="<br />Die Installation kann ohne Probleme weiter
 INSTL_OUTPUT_BUFFERING="Gepufferte Ausgabe"
 INSTL_PARSE_INI_FILE_AVAILABLE="INI-Parser-Unterstützung"
 INSTL_PHP_VERSION="PHP-Version"
+INSTL_PHP_VERSION_NEWER="PHP-Version >= %s"
 INSTL_REGISTER_GLOBALS="Register Globals Aus"
 INSTL_SAFE_MODE="Safe-Mode"
 INSTL_SESSION_AUTO_START="Automatischer Sitzungsstart (Session)"


### PR DESCRIPTION
siehe: https://github.com/joomla/joomla-cms/commit/6202214f760e04300dfd412c0fc42063c5bcdee2