### PR TITLE
entfernen des beschreibungstags von der installations xml

### DIFF
--- a/installation/language/de-DE/de-DE.xml
+++ b/installation/language/de-DE/de-DE.xml
@@ -6,7 +6,6 @@
     <author>J!German</author>
     <copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <description></description>
     <files>
         <filename>de-DE.ini</filename>
     </files>


### PR DESCRIPTION
Siehe https://github.com/joomla/joomla-cms/pull/8546

Noch nicht gemerged aber wir sollten es spätestens nach dem merge zurück syncen ob es in 3.5.0 oder 3.5.1 geht ist meiner Meinung nach egal ;)