### PR TITLE
Joomla wird immer angezeigt. Wenn diese Option auf ja gesetzt ist

### DIFF
--- a/administrator/language/de-DE/de-DE.mod_version.ini
+++ b/administrator/language/de-DE/de-DE.mod_version.ini
@@ -9,6 +9,6 @@ MOD_VERSION_FORMAT_DESC="Das ausführliche Format enthält den Codenamen und das
 MOD_VERSION_FORMAT_LABEL="Versionsformat"
 MOD_VERSION_FORMAT_LONG="Ausführlich"
 MOD_VERSION_FORMAT_SHORT="Abgekürzt"
-MOD_VERSION_PRODUCT_DESC="Den Joomla!-Namen beim abgekürzten Format anzeigen."
+MOD_VERSION_PRODUCT_DESC="Den Joomla!-Namen anzeigen."
 MOD_VERSION_PRODUCT_LABEL="Joomla! anzeigen"
 MOD_VERSION_XML_DESCRIPTION="Dieses Modul zeigt die installierte Joomla!-Version an."


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Joomla wird immer angezeigt. Wenn diese Option auf ja gesetzt ist

### Wie kann der Fehler nachgestellt werden

Optionen von mod_version ausprobieren.
Version Format: lang
Joomla anzeigen: Ja

### Das erwartete Ergebnis

Laut tooltip wird Joomla nicht angezeigt (lang + Ja)

### Das aktuelle Ergebnis

Auch in der lang version wird die Option "Joomla anzeigen" berücksichtigt daher sollte die beschreibung angepasst werden.

### System Information

siehe CMS: https://github.com/joomla/joomla-cms/pull/14568
