### PR TITLE
4.0 dev

### DIFF
--- a/administrator/language/de-DE/de-DE.plg_editors_tinymce.ini
+++ b/administrator/language/de-DE/de-DE.plg_editors_tinymce.ini
@@ -141,7 +141,7 @@ PLG_TINY_FIELD_VISUALBLOCKS_DESC="Ermöglicht die Anzeige der HTML-Block-Element
 PLG_TINY_FIELD_VISUALBLOCKS_LABEL="Visuelle Blöcke"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Wortzähler an/aus"
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Wortzähler"
-PLG_TINY_LEGACY_WARNING="Das <a href=\"%s\">TinyMCE-Editor-Plugin</a> wurde aktualisiert. Im Moment verwendet es eine Vorgänger-Konfiguration. Durch das Bearbeiten des Plugins können nun bestimmten Layouts verschieden Benutzergruppen zugeordnet werden.<br /><br /><span style=\"text-decoration: underline; color: red;\"><strong>Warnung:</strong></span><br />Bei der Bearbeitung des Plugins gehen alle vorherigen Einstellung verloren!"
+PLG_TINY_LEGACY_WARNING="Das <a href=\"%s\">TinyMCE-Editor-Plugin</a> wurde aktualisiert. Im Moment verwendet es eine Vorgänger-Konfiguration. Durch das Bearbeiten des Plugins können nun bestimmten Layouts verschieden Benutzergruppen zugeordnet werden.<br /><br /><span style=\"text-decoration: underline; color: red;\"><strong>Warnung:</strong></span><br />Bei der Bearbeitung des Plugins gehen alle vorherigen Einstellungen verloren!"
 PLG_TINY_SET_TARGET_PANEL_DESCRIPTION="<strong>Existing sets of the TinyMCE panel, and options for each.</strong><br />In each set you can add new menus or buttons from <strong>the list of available menus and buttons</strong> or remove unneeded."
 PLG_TINY_SET_TITLE="Voreinstellung %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Erweiterte Voreinstellung"

--- a/administrator/language/de-DE/de-DE.plg_editors_tinymce.ini
+++ b/administrator/language/de-DE/de-DE.plg_editors_tinymce.ini
@@ -141,7 +141,7 @@ PLG_TINY_FIELD_VISUALBLOCKS_DESC="Ermöglicht die Anzeige der HTML-Block-Element
 PLG_TINY_FIELD_VISUALBLOCKS_LABEL="Visuelle Blöcke"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Wortzähler an/aus"
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Wortzähler"
-PLG_TINY_LEGACY_WARNING="Das <a href=\"%s\">TinyMCE-Editor-Plugin</a> wurde aktualisiert. Im Moment verwendet es eine Vorgänger-Konfiguration. Durch das Bearbeiten des Plugins können nun bestimmten Layouts verschieden Benutzergruppen zugeordnet werden.<br /><br /><span style=\"text-decoration: underline; color: red;\"><strong>Warnung:</strong></span><br />Bei der Bearbeitung des Plugins, gehen alle vorherigen Einstellung verlohren!"
+PLG_TINY_LEGACY_WARNING="Das <a href=\"%s\">TinyMCE-Editor-Plugin</a> wurde aktualisiert. Im Moment verwendet es eine Vorgänger-Konfiguration. Durch das Bearbeiten des Plugins können nun bestimmten Layouts verschieden Benutzergruppen zugeordnet werden.<br /><br /><span style=\"text-decoration: underline; color: red;\"><strong>Warnung:</strong></span><br />Bei der Bearbeitung des Plugins gehen alle vorherigen Einstellung verloren!"
 PLG_TINY_SET_TARGET_PANEL_DESCRIPTION="<strong>Existing sets of the TinyMCE panel, and options for each.</strong><br />In each set you can add new menus or buttons from <strong>the list of available menus and buttons</strong> or remove unneeded."
 PLG_TINY_SET_TITLE="Voreinstellung %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Erweiterte Voreinstellung"


### PR DESCRIPTION
Pull Request für Issue #317 

### Wie kann der Fehler nachgestellt werden
Tippehler bei der Meldung

domain.tld/administrator/index.php?option=com_plugins&amp;task=plugin.edit&amp;extension_id=412

### Das erwartete Ergebnis

WARNUNG:
Bei der Bearbeitung des Plugins, gehen alle vorherigen Einstellungen verloren!

### Das aktuelle Ergebnis

Bei der Bearbeitung des Plugins, gehen alle vorherigen Einstellung verloren!

### System Information

3.8.4v1

### Zusätzlichen Informationen

Liebes Übersetzer-Team,

beim Aufruf eines Beitrags mit dem alten Editor erscheint immer die
angehängte Warnmeldung. Bei der Erstellung der deutschen Übersetzung
für Joomla 3.8.3. könnte bitte Folgendes geändert werden:
- Komma nach "Plugins" streichen
- h in "verlohren" streichen

Per E-Mail vom 12.12.2017 Herr Erli (@sisko1990)