### PR TITLE
[3.9] Add missing language string COM_USERS_LOGIN_DEFAULT_LABEL

### DIFF
--- a/language/de-DE/de-DE.com_users.ini
+++ b/language/de-DE/de-DE.com_users.ini
@@ -42,6 +42,7 @@ COM_USERS_FIELD_RESET_PASSWORD1_MESSAGE="Die eingegebenen Passwörter stimmen ni
 COM_USERS_FIELD_RESET_PASSWORD2_DESC="Neues Passwort bestätigen"
 COM_USERS_FIELD_RESET_PASSWORD2_LABEL="Passwort bestätigen"
 COM_USERS_INVALID_EMAIL="Ungültige E-Mail-Adresse"
+COM_USERS_LOGIN_DEFAULT_LABEL="Benutzerlogin"
 COM_USERS_LOGIN_IMAGE_ALT="Anmeldebild"
 COM_USERS_LOGIN_REGISTER="Noch kein Benutzerkonto erstellt?"
 COM_USERS_LOGIN_REMEMBER_ME="Angemeldet bleiben"


### PR DESCRIPTION
https://github.com/joomlagerman/joomla/issues/469