### PR TITLE
[3.9] [com_fields] Error message when creating a field with a name already existing 

### DIFF
--- a/administrator/language/de-DE/de-DE.com_fields.ini
+++ b/administrator/language/de-DE/de-DE.com_fields.ini
@@ -7,7 +7,7 @@
 COM_FIELDS="Felder"
 COM_FIELDS_BATCH_GROUP_LABEL="Zum Verschieben oder Kopieren der Auswahl eine Gruppe auswählen."
 COM_FIELDS_BATCH_GROUP_OPTION_NONE="- Keine Gruppe -"
-COM_FIELDS_ERROR_UNIQUE_NAME="Ein anderes Feld hat denselben Namen (ggf. auch im Papierkorb)."
+COM_FIELDS_ERROR_UNIQUE_NAME="Ein anderes Feld hat denselben Namen (ggf. auch im Papierkorb oder in einer anderen Komponente)."
 COM_FIELDS_FIELD_CLASS_DESC="Das CSS-Klassenattribut für das Feld in der Eingabemaske. Bei mehreren Klassen mit Leerzeichen trennen."
 COM_FIELDS_FIELD_CLASS_LABEL="Feldklasse"
 COM_FIELDS_FIELD_FORMOPTIONS_HEADING="Eingabemaske-Optionen"


### PR DESCRIPTION
https://github.com/joomlagerman/joomla/issues/528

Original:
COM_FIELDS_ERROR_UNIQUE_NAME="Another Field has the same name (remember it may be a trashed item or it may be already present as a custom field in another extension)."

da wir hier immer über ein Custom field sprechen hab ich das direkt raus gestrichen. Aber ist das custom field "in" einer anderen Komponente? Was denkt Ihr?