### PR TITLE
Text vereinacht und umformuliert, so dass keine direkte Anrede mehr enthalten ist

### DIFF
--- a/language/de-DE/de-DE.com_privacy.ini
+++ b/language/de-DE/de-DE.com_privacy.ini
@@ -12,7 +12,7 @@ COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT="Informationsanfrage
 COM_PRIVACY_CONFIRM_REMIND_SUCCEEDED="Ihre Zustimmung zur Datenschutzerklärung dieser Webseite ist abgelaufen."
 COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="Eine E-Mail wurde an Ihre E-Mail-Adresse gesendet. Die E-Mail enthält ein Sicherheitstoken. Bitte bestätigen Sie Ihre E-Mail-Adresse erneut und fügen Sie das Sicherheitstoken in das nachfolgende Feld ein, um zu bestätigen, dass Sie der Inhaber der angeforderten Informationen sind."
 COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Ihre Informationsanfrage wurde bestätigt."
-COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Die Informationsanfrage ist eingegangen. Bevor diese bearbeitet werden kann, muss sie bestätigt werden. Eine E-Mail mit zusätzlichen Anweisungen wurde an die Adresse des Anfragers gesandt."
+COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Die Informationsanfrage ist eingegangen. Bevor diese bearbeitet werden kann, muss sie bestätigt werden. Dazu wurde eine E-Mail mit zusätzlichen Anweisungen an die Adresse des Anfragenden gesandt."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:
 ; [SITENAME]  Site name, as set in Global Configuration.
 ; [URL]       URL of the site's frontend page.

--- a/language/de-DE/de-DE.com_privacy.ini
+++ b/language/de-DE/de-DE.com_privacy.ini
@@ -12,7 +12,7 @@ COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT="Informationsanfrage
 COM_PRIVACY_CONFIRM_REMIND_SUCCEEDED="Ihre Zustimmung zur Datenschutzerklärung dieser Webseite ist abgelaufen."
 COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="Eine E-Mail wurde an Ihre E-Mail-Adresse gesendet. Die E-Mail enthält ein Sicherheitstoken. Bitte bestätigen Sie Ihre E-Mail-Adresse erneut und fügen Sie das Sicherheitstoken in das nachfolgende Feld ein, um zu bestätigen, dass Sie der Inhaber der angeforderten Informationen sind."
 COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Ihre Informationsanfrage wurde bestätigt."
-COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Ihre Informationsanforderung wurde erstellt. Bevor diese verarbeitet werden kann, müssen Sie diese Anfrage bestätigen. Eine E-Mail wurde mit zusätzlichen Anweisungen an Ihre Adresse gesendet, um diese Überprüfung abzuschließen."
+COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Die Informationsanfrage ist eingegangen. Bevor diese bearbeitet werden kann, muss sie bestätigt werden. Eine E-Mail mit zusätzlichen Anweisungen wurde an die Adresse des Anfragers gesandt."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:
 ; [SITENAME]  Site name, as set in Global Configuration.
 ; [URL]       URL of the site's frontend page.


### PR DESCRIPTION
String COM_PRIVACY_CREATE_REQUEST_SUCCEEDED vereinfacht und Anrede in allgemeine Formulierung geändert.

Zu gesendet und gesandt: "In der Bedeutung »schicken« sind die Vergangenheitsformen mit »a« häufiger." (https://www.duden.de/rechtschreibung/senden)

Text erscheint, nachdem Daten angefordert werden im Frontend: 
![home](https://user-images.githubusercontent.com/9974686/45448662-3c404600-b6d3-11e8-996f-14d32642a519.png)
