### PR TITLE
[3.9]Typo in der Admin Module Beschreibung

### DIFF
--- a/administrator/language/de-DE/de-DE.mod_toolbar.ini
+++ b/administrator/language/de-DE/de-DE.mod_toolbar.ini
@@ -5,4 +5,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_TOOLBAR="Werkzeugleiste"
-MOD_TOOLBAR_XML_DESCRIPTION="Dieses Modul zeigt die Werkzeugsymbole (z.&#8239;B. „Neu“, „Bearbeiten“, etc.) an, die benutzt werden, um Tätigkeiten im Administratorbereich zu steuern."
+MOD_TOOLBAR_XML_DESCRIPTION="Dieses Modul zeigt die Werkzeugsymbole (z. B. „Neu“, „Bearbeiten“, etc.) an, die benutzt werden, um Tätigkeiten im Administratorbereich zu steuern."


### PR DESCRIPTION
Pull Request für Issue #609  .

### Zusammenfassung der Änderungen

In this special case z.&#8239;B. is not working.
It's not a typo. Typographic blank, which can not be rendered here.
Thanks @blueforce for your hint.

### Das erwartete Ergebnis

Dieses Modul zeigt die Werkzeugsymbole (z. B. „Neu“, „Bearbeiten“, etc.) an, die benutzt werden, um Tätigkeiten im Administratorbereich zu steuern.

### Das aktuelle Ergebnis

Dieses Modul zeigt die Werkzeugsymbole (z.&#8239;B. „Neu“, „Bearbeiten“, etc.) an, die benutzt werden, um Tätigkeiten im Administratorbereich zu steuern.

### System Information

3.1.4v1 -> 3.9-beta-2