### PR TITLE
[3.9] Add missing installer string about PDO PostgreSQL support

### DIFF
--- a/installation/language/de-DE/de-DE.ini
+++ b/installation/language/de-DE/de-DE.ini
@@ -206,6 +206,7 @@ INSTL_DATABASE_FIX_TOO_LONG="Der MySQL-Tabellenpräfix darf maximal 15 Zeichen l
 INSTL_DATABASE_INVALID_DB_DETAILS="Die eingegebenen Datenbankangaben sind nicht korrekt und/oder leer!"
 INSTL_DATABASE_INVALID_MYSQL_VERSION="Um die Installation fortzusetzen wird MySQL 5.0.4 oder höher benötigt. Die installierte Version ist aber: %s"
 INSTL_DATABASE_INVALID_MYSQLI_VERSION="Um die Installation fortzusetzen wird MySQL 5.0.4 oder höher benötigt. Die installierte Version ist aber: %s"
+INSTL_DATABASE_INVALID_PGSQL_VERSION="Um die Installation fortzusetzen wird PostgreSQL 8.3.18 oder höher benötigt. Die installierte Version ist aber: %s"
 INSTL_DATABASE_INVALID_PDOMYSQL_VERSION="Um die Installation fortzusetzen wird MySQL 5.0.4 oder höher benötigt. Die installierte Version ist aber: %s"
 INSTL_DATABASE_INVALID_POSTGRESQL_VERSION="Um die Installation fortzusetzen wird PostgreSQL 8.3.18 oder höher benötigt. Die installierte Version ist aber: %s"
 INSTL_DATABASE_INVALID_SQLSRV_VERSION="Um die Installation fortzusetzen wird der SQL-Server 2008 R2 (10.50.1600.1) oder höher benötigt. Die installierte Version ist aber: %s"


### PR DESCRIPTION
It looks like we missed here: https://github.com/joomlagerman/joomla/pull/471 this string that was also be added by https://github.com/joomla/joomla-cms/pull/20386 fixed here.