### PR TITLE
Standard Module übersetzen

### DIFF
--- a/installation/sql/mysql/localise.sql
+++ b/installation/sql/mysql/localise.sql
@@ -45,7 +45,6 @@ UPDATE IGNORE `#__viewlevels` SET `title` = 'Spezial' WHERE `id` = 3;
 UPDATE IGNORE `#__viewlevels` SET `title` = 'Gast' WHERE `id` = 5;
 UPDATE IGNORE `#__viewlevels` SET `title` = 'Super Benutzer' WHERE `id` = 6;
 
-
 --
 -- Table `#__modules`
 --

--- a/installation/sql/mysql/localise.sql
+++ b/installation/sql/mysql/localise.sql
@@ -44,3 +44,26 @@ UPDATE IGNORE `#__viewlevels` SET `title` = 'Registriert' WHERE `id` = 2;
 UPDATE IGNORE `#__viewlevels` SET `title` = 'Spezial' WHERE `id` = 3;
 UPDATE IGNORE `#__viewlevels` SET `title` = 'Gast' WHERE `id` = 5;
 UPDATE IGNORE `#__viewlevels` SET `title` = 'Super Benutzer' WHERE `id` = 6;
+
+
+--
+-- Table `#__modules`
+--
+UPDATE IGNORE `#__modules` SET `title` = 'Hauptmenü' WHERE `id` = 1;
+UPDATE IGNORE `#__modules` SET `title` = 'Anmeldung' WHERE `id` = 2;
+UPDATE IGNORE `#__modules` SET `title` = 'Beliebte Beiträge' WHERE `id` = 3;
+UPDATE IGNORE `#__modules` SET `title` = 'Kürzlich hinzugefügte Beiträge' WHERE `id` = 4;
+UPDATE IGNORE `#__modules` SET `title` = 'Symbolleiste' WHERE `id` = 8;
+UPDATE IGNORE `#__modules` SET `title` = 'Schnellzugriff' WHERE `id` = 9;
+UPDATE IGNORE `#__modules` SET `title` = 'Angemeldete Benutzer' WHERE `id` = 10;
+UPDATE IGNORE `#__modules` SET `title` = 'Admin Menü' WHERE `id` = 12;
+UPDATE IGNORE `#__modules` SET `title` = 'Admin Submenü' WHERE `id` = 13;
+UPDATE IGNORE `#__modules` SET `title` = 'Benutzerstatus' WHERE `id` = 14;
+UPDATE IGNORE `#__modules` SET `title` = 'Titel' WHERE `id` = 15;
+UPDATE IGNORE `#__modules` SET `title` = 'Anmeldeformular' WHERE `id` = 16;
+UPDATE IGNORE `#__modules` SET `title` = 'Navigationspfad' WHERE `id` = 17;
+UPDATE IGNORE `#__modules` SET `title` = 'Mehrsprachenstatus' WHERE `id` = 79;
+UPDATE IGNORE `#__modules` SET `title` = 'Joomla Version' WHERE `id` = 86;
+UPDATE IGNORE `#__modules` SET `title` = 'Beispieldaten' WHERE `id` = 87;
+UPDATE IGNORE `#__modules` SET `title` = 'Letzte Aktionen' WHERE `id` = 88;
+UPDATE IGNORE `#__modules` SET `title` = 'Dashboard für den Datenschutz' WHERE `id` = 89;

--- a/installation/sql/mysql/localise.sql
+++ b/installation/sql/mysql/localise.sql
@@ -65,4 +65,4 @@ UPDATE IGNORE `#__modules` SET `title` = 'Mehrsprachenstatus' WHERE `id` = 79;
 UPDATE IGNORE `#__modules` SET `title` = 'Joomla Version' WHERE `id` = 86;
 UPDATE IGNORE `#__modules` SET `title` = 'Beispieldaten' WHERE `id` = 87;
 UPDATE IGNORE `#__modules` SET `title` = 'Letzte Aktionen' WHERE `id` = 88;
-UPDATE IGNORE `#__modules` SET `title` = 'Dashboard für den Datenschutz' WHERE `id` = 89;
+UPDATE IGNORE `#__modules` SET `title` = 'Datenschutz Kontrollzentrum' WHERE `id` = 89;


### PR DESCRIPTION
Pull Request für Issue https://github.com/joomlagerman/joomla/issues/437

### Zusammenfassung der Änderungen

Im de-DE Neu Installationspaket werden nun auch die Standard Module übersetzt.
Das hier: https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1522-L1540 sind die originalen Texte plus ID, bitte prüfen.

### Wie kann der Fehler nachgestellt werden

Installation alter Installationspakete => englische Modul title
