### PR TITLE
[3.x] Mark strings for robots options as not to translate Closes #1125

### DIFF
--- a/administrator/language/de-DE/de-DE.ini
+++ b/administrator/language/de-DE/de-DE.ini
@@ -432,7 +432,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Anzahl Versionen"
 JGLOBAL_HITS="Zugriffe"
 JGLOBAL_HITS_ASC="Zugriffe aufsteigend"
 JGLOBAL_HITS_DESC="Zugriffe absteigend"
+; Please do not translate the following language string
 JGLOBAL_INDEX_FOLLOW="index, follow"
+; Please do not translate the following language string
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Vererbt"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -486,7 +488,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="Neue Einträge an erster Stelle. Die Reihenfolge kan
 JGLOBAL_NEWITEMSLAST_DESC="Neue Einträge werden immer am Ende eingefügt. Die Reihenfolge kann nach dem Speichern dieses Eintrags geändert werden."
 JGLOBAL_NO_ITEM_SELECTED="Keine Einträge ausgewählt!"
 JGLOBAL_NO_ORDER="Keine Sortierung"
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_COLUMNS_DESC="Anzahl Spalten für die Einleitungstexte der Beiträge; normalerweise 1, 2 oder 3. <strong>Das Template muss die Zahl der gewählten Spalten unterstützen und entsprechende CSS-Definitionen enthalten.</strong>"


### PR DESCRIPTION
Pull Request für Issue #1125

### Zusammenfassung der Änderungen

Mark strings for robots options as not to translate

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

Backend Globale Konfiguration
