### PR TITLE
[3.9] Fix escaped HTML code in error message

### DIFF
--- a/language/de-DE/de-DE.com_users.ini
+++ b/language/de-DE/de-DE.com_users.ini
@@ -4,7 +4,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-COM_USERS_ACTIVATION_TOKEN_NOT_FOUND="Der Bestätigungscode konnte <strong><u>nicht</u></strong> gefunden werden! Das Benutzer-Konto wurde möglicherweise bereits aktiviert, bitte erneut versuchen sich anzumelden."
+COM_USERS_ACTIVATION_TOKEN_NOT_FOUND="Der Bestätigungscode konnte nicht gefunden werden! Das Benutzer-Konto wurde möglicherweise bereits aktiviert, bitte erneut versuchen sich anzumelden."
 COM_USERS_CAPTCHA_LABEL="Captcha"
 COM_USERS_CAPTCHA_DESC="Bitte die Sicherheitsüberprüfung ausfüllen."
 COM_USERS_DATABASE_ERROR="Datenbankfehler beim Auslesen des Benutzers: %s"


### PR DESCRIPTION
Pull Request für Issue # .

### Zusammenfassung der Änderungen
Wenn ein Nutzer ein zweites Mal auf den Aktivierungslink nach der Registrierung klickt, bekommt er die von mir geänderte Fehlermeldung. Diese wird aber HTML-escaped, somit wird der HTML Code ausgegeben.


### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
User Registrierung mit User-Aktivierung. Zweimal auf den Aktivierungslink klicken.

