### PR TITLE
[4.0] Textfiltereinstellungen translation missing in com_config.ini

### DIFF
--- a/administrator/language/de-DE/com_config.ini
+++ b/administrator/language/de-DE/com_config.ini
@@ -222,7 +222,7 @@ COM_CONFIG_TEXT_FILTER_SETTINGS="Textfiltereinstellungen"
 COM_CONFIG_TEXT_FILTERS="Textfilter"
 COM_CONFIG_TEXT_FILTERS_DESC="Diese Textfiltereinstellungen werden auf alle Texteditorfelder angewandt, die von Benutzern der gewählten Gruppe eingereicht werden.<br />Diese Einstellungen ermöglichen die Kontrolle über den HTML-Code, den Beitragsautoren einreichen können. Die Voreinstellung bietet einen brauchbaren Schutz gegen übliche Angriffe auf die Site und deren Code."
 COM_CONFIG_TEXT_FILTERS_NOTE="WARNUNG: Eine übergeordnete Gruppe wurde mit der Einstellung 'Keine Filterung' konfiguriert. Diese Einstellung kann in untergeordneten Gruppen nicht überschrieben werden, und andere konfigurierte Filter werden nicht angewendet."
-COM_CONFIG_TEXT_FILTERS_SUMMARY="Expand for notes about the text filters"
+COM_CONFIG_TEXT_FILTERS_SUMMARY="Hinweise zu den Textfiltern"
 COM_CONFIG_XML_DESCRIPTION="Konfiguration"
 
 ; Alternate language strings for the rules form field


### PR DESCRIPTION
Pull Request für Issue #1566 .

### Zusammenfassung der Änderungen

fix translation

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

backend
