### PR TITLE
fix new syntax for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,3 +1,9 @@
+---
+name: basic issue template
+about: Use this template for issues.
+assignees: tecpromotion, zero-24
+---
+
 ### Was soll verbessert / korrigiert werden
 
 


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Regarding to our orange bubble at the checklist and https://docs.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository

<img width="934" alt="Bildschirmfoto 2021-01-23 um 12 31 56" src="https://user-images.githubusercontent.com/1752513/105576992-09182200-5d77-11eb-903d-6ef4b8e1429f.png">
