### PR TITLE
Verbessere Styling der Hinweis-Tabelle

### DIFF
--- a/pkg_de-DE.xml
+++ b/pkg_de-DE.xml
@@ -17,12 +17,12 @@
         <h2>Deutsches Sprachpaket für Joomla! 3.9.24 von <a title="J!German" href="https://www.jgerman.de" target="_blank">J!German</a></h2>
         <h3><span style="color: #008000;">Übersetzungsversion: 3.9.24.1</span></h3>
         <hr />
-        <table rules="all" frame="border" style="width: 90%; border-color: #000000; border-width: 1px; border-style: solid;" align="center" border="1">
+        <table class="table table-bordered" style="width: 90%;" align="center">
         <colgroup> <col width="30%" /> <col width="60" /> </colgroup>
         <tbody>
           <tr>
             <td>
-              <ul>
+              <ul class="unstyled">
                 <li>Frontend (Website)-Übersetzung</li>
               </ul>
             </td>
@@ -44,7 +44,7 @@
           </tr>
           <tr>
             <td>
-              <ul>
+              <ul class="unstyled">
                 <li>Backend (Administrator)-Übersetzung</li>
               </ul>
             </td>

--- a/pkg_de-DE.xml
+++ b/pkg_de-DE.xml
@@ -13,46 +13,13 @@
 	<packager />
 	<packagerurl />
 	<description><![CDATA[
-	<div style="text-align: center;">
+	<div>
         <h2>Deutsches Sprachpaket für Joomla! 3.9.24 von <a title="J!German" href="https://www.jgerman.de" target="_blank">J!German</a></h2>
         <h3><span style="color: #008000;">Übersetzungsversion: 3.9.24.1</span></h3>
         <hr />
-        <table class="table table-bordered" style="width: 90%;" align="center">
-        <colgroup> <col width="30%" /> <col width="60" /> </colgroup>
-        <tbody>
-          <tr>
-            <td>
-              <ul class="unstyled">
-                <li>Frontend (Website)-Übersetzung</li>
-              </ul>
-            </td>
-            <td rowspan="2">
-              <ul>
-                <li>
-                  <span style="text-decoration: underline;">Neuinstallation:</span>
-                  <br />
-                  Legen Sie die deutsche Sprache unter <a title="Language(s)" href="index.php?option=com_languages" target="_blank">„Extensions“ → „Language(s)“</a> als Standardsprache („Default“), sowohl für die Website („Installed - Site“) als auch für die Administration („Installed - Administrator“), fest.
-                </li>
-                <br />
-                <li>
-                  <span style="text-decoration: underline;">Aktualisierung:</span>
-                  <br />
-                  Es sind keine weiteren Schritte erforderlich.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <ul class="unstyled">
-                <li>Backend (Administrator)-Übersetzung</li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-        </table>
-        <br />
-        <span style="text-decoration: underline;">Hinweis:</span> Dieses Paket unterstützt die Joomla! eigene <a title="Joomla!-Aktualisierungsfunktion" href="index.php?option=com_installer&amp;view=update" target="_blank">Aktualisierungsfunktion</a>!
+        <p><span style="text-decoration: underline;">Neuinstallation:</span> Legen Sie die deutsche Sprache unter <a title="Language(s)" href="index.php?option=com_languages" target="_blank">„Extensions“ → „Language(s)“</a> als Standardsprache („Default“), sowohl für die Website („Installed - Site“) als auch für die Administration („Installed - Administrator“), fest.</p>
+        <p><span style="text-decoration: underline;">Aktualisierung:</span> Es sind keine weiteren Schritte erforderlich.</p>
+        <p><span style="text-decoration: underline;">Hinweis:</span> Dieses Paket unterstützt die Joomla! eigene <a title="Joomla-Aktualisierungsfunktion" href="index.php?option=com_installer&amp;view=update" target="_blank">Aktualisierungsfunktion</a>.</p>
       </div>]]>
 	</description>
 	<blockChildUninstall>true</blockChildUninstall>

--- a/pkg_de-DE.xml
+++ b/pkg_de-DE.xml
@@ -13,14 +13,14 @@
 	<packager />
 	<packagerurl />
 	<description><![CDATA[
-	<div>
         <h2>Deutsches Sprachpaket für Joomla! 3.9.24 von <a title="J!German" href="https://www.jgerman.de" target="_blank">J!German</a></h2>
         <h3><span style="color: #008000;">Übersetzungsversion: 3.9.24.1</span></h3>
         <hr />
-        <p><span style="text-decoration: underline;">Neuinstallation:</span> Legen Sie die deutsche Sprache unter <a title="Language(s)" href="index.php?option=com_languages" target="_blank">„Extensions“ → „Language(s)“</a> als Standardsprache („Default“), sowohl für die Website („Installed - Site“) als auch für die Administration („Installed - Administrator“), fest.</p>
-        <p><span style="text-decoration: underline;">Aktualisierung:</span> Es sind keine weiteren Schritte erforderlich.</p>
-        <p><span style="text-decoration: underline;">Hinweis:</span> Dieses Paket unterstützt die Joomla! eigene <a title="Joomla-Aktualisierungsfunktion" href="index.php?option=com_installer&amp;view=update" target="_blank">Aktualisierungsfunktion</a>.</p>
-      </div>]]>
+        <p><span style="text-decoration: underline;">Neuinstallation:</span><br />Die deutsche Sprache kann unter <a title="Language(s)" href="index.php?option=com_languages" target="_blank">„Extensions“ → „Language(s)“</a> als Standardsprache (Default), sowohl für die Website „Installed (Site)“ als auch für die Administration „Installed (Administrator)“, festgelegt werden.</p>
+        <p><span style="text-decoration: underline;">Aktualisierung:</span><br />Es sind keine weiteren Schritte erforderlich.</p>
+	<p><span style="text-decoration: underline;">Fehler:</span><br />Übersetzungsfehler, Tippfehler oder Anregungen können gerne auf GitHub im <a href="https://github.com/joomlagerman/joomla" target="_blank" title="https://github.com/joomlagerman/joomla">joomlagerman/joomla</a> Repository gemeldet werden.</p>
+        <p><span style="text-decoration: underline;">Hinweis:</span><br />Dieses Paket unterstützt die Joomla! eigene <a title="Joomla-Aktualisierungsfunktion" href="index.php?option=com_installer&amp;view=update" target="_blank">Aktualisierungsfunktion</a>.</p>
+	]]>
 	</description>
 	<blockChildUninstall>true</blockChildUninstall>
 	<files>


### PR DESCRIPTION
Eine kleine Styling-Verbesserung für die Übersichtstabelle bei der Installation.
Kam heute auf  in einem Gespräch mit @zero-24 und @HLeithner (#1603 )

Hinweis: Das Backendtemplate muss natürlich die Klassen unterstützen.