### PR TITLE
[4.0] Typo fixed

### DIFF
--- a/language/de-DE/mod_syndicate.ini
+++ b/language/de-DE/mod_syndicate.ini
@@ -12,4 +12,4 @@ MOD_SYNDICATE_FIELD_TEXT_DESC="Sollte das Feld leer bleiben, wird ein Standardte
 MOD_SYNDICATE_FIELD_TEXT_LABEL="Label"
 MOD_SYNDICATE_FIELD_VALUE_ATOM="Atom 1.0"
 MOD_SYNDICATE_FIELD_VALUE_RSS="RSS 2.0"
-MOD_SYNDICATE_XML_DESCRIPTION="Kleines Syndication-Modul, dass einen Feed für die gerade angezeigte Website zur Verfügung stellt."
+MOD_SYNDICATE_XML_DESCRIPTION="Kleines Syndication-Modul, das einen Feed für die gerade angezeigte Website zur Verfügung stellt."

--- a/language/de-DE/mod_syndicate.sys.ini
+++ b/language/de-DE/mod_syndicate.sys.ini
@@ -6,4 +6,4 @@
 
 MOD_SYNDICATE="Feeds - Feed erzeugen"
 MOD_SYNDICATE_LAYOUT_DEFAULT="Standard"
-MOD_SYNDICATE_XML_DESCRIPTION="Kleines Syndication-Modul, dass einen Feed für die gerade angezeigte Website zur Verfügung stellt."
+MOD_SYNDICATE_XML_DESCRIPTION="Kleines Syndication-Modul, das einen Feed für die gerade angezeigte Website zur Verfügung stellt."


### PR DESCRIPTION
### Zusammenfassung der Änderungen
2 Schreibfehler korrigiert


### Wo wird der Sprachstring angezeigt:
Backend

