### PR TITLE
Update to the new server url

### DIFF
--- a/pkg_de-DE.xml
+++ b/pkg_de-DE.xml
@@ -28,6 +28,6 @@
 		<file type="language" client="administrator" id="de-DE">admin_de-DE.zip</file>
 	</files>
 	<updateservers>
-		<server type="collection" priority="1" name="Accredited Joomla! Translations">https://update.joomla.org/language/translationlist_3.xml</server>
+		<server type="collection" priority="1" name="Accredited Joomla! Translations">https://update.joomla.org/language/translationlist_4.xml</server>
 	</updateservers>
 </extension>


### PR DESCRIPTION
Clean Joomla install only proposes German to be installed, but we get an error.
<img width="1294" alt="Screen Shot 2021-06-01 at 09 13 31" src="https://user-images.githubusercontent.com/869724/120285430-87547a00-c2bd-11eb-8429-6a8613067419.png">


Pull Request für Issue # .

### Zusammenfassung der Änderungen



### Wo wird der Sprachstring angezeigt / Wie kann getestet werden


