### PR TITLE
[4.0] Remove com_messages.ini in frontend

### DIFF
--- a/language/de-DE/com_messages.ini
+++ b/language/de-DE/com_messages.ini
@@ -1,9 +1,0 @@
-; Joomla! German Translation
-; (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
-; (C) Translation 2008 - 2021 J!German <https://www.jgerman.de>
-; License GNU General Public License version 2 or later; see LICENSE.txt
-; Note : All ini files need to be saved as UTF-8
-
-COM_MESSAGES_ERR_SEND_FAILED="Der Benutzer hat seinen Posteingang gesperrt! Die Benachrichtigung ist <strong>fehlgeschlagen</strong>."
-COM_MESSAGES_NEW_MESSAGE="Es ist eine neue private Nachricht von %1$s auf %2$s eingegangen."
-COM_MESSAGES_PLEASE_LOGIN="Bitte in %s anmelden um die Nachricht zu lesen."


### PR DESCRIPTION
Pull Request für Issue #1947.

### Zusammenfassung der Änderungen
**Gelöscht:** language/de-DE/com_messages.ini


### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
Frontend

