### PR TITLE
array usage

### DIFF
--- a/script.php
+++ b/script.php
@@ -28,7 +28,7 @@ class Pkg_deDEInstallerScript extends InstallerScript
 		$this->minimumJoomla = '4.0';
 		$this->minimumPhp    = '7.2.5';
 
-		$this->deleteFiles = array(
+		$this->deleteFiles = [
 			// Backend
 			'/administrator/language/de-DE/de-DE.com_actionlogs.ini',
 			'/administrator/language/de-DE/de-DE.com_actionlogs.sys.ini',
@@ -406,7 +406,7 @@ class Pkg_deDEInstallerScript extends InstallerScript
 			'/language/de-DE/de-DE.tpl_protostar.ini',
 			'/language/de-DE/de-DE.tpl_protostar.sys.ini',
 			'/language/de-DE/de-DE.xml',
-		);
+		];
 	}
 
 	/**


### PR DESCRIPTION
### Zusammenfassung der Änderungen

from docu https://developer.joomla.org/coding-standards/php-code.html
Assignments (the => operator) in arrays may be aligned with spaces. When splitting array definitions onto several lines, the last value should also have a trailing comma. This is valid PHP syntax and helps to keep code diffs minimal. Joomla 3 prefers array() to be backward compatible to 5.3.10 and Joomla 4.0.0 onwards should use the short array syntax [] by default. (Short array syntax was introduced in PHP 5.4.)

For example:

```
$options = [
	'foo'  => 'foo',
	'spam' => 'spam',
];

```