### PR TITLE
[4.1] Update com_modules.sys

### DIFF
--- a/administrator/language/de-DE/com_modules.sys.ini
+++ b/administrator/language/de-DE/com_modules.sys.ini
@@ -6,7 +6,6 @@
 
 COM_MODULES="Module"
 COM_MODULES_ACTION_EDITFRONTEND="Frontend-Bearbeitung"
-COM_MODULES_ACTION_EDITFRONTEND_COMPONENT_DESC="Ermöglicht es Benutzern in dieser Gruppe, Module im Frontend zu bearbeiten."
 COM_MODULES_GENERAL="Allgemein"
 COM_MODULES_MODULES_VIEW_DEFAULT_DESC="Zeigt die Liste der Module."
 COM_MODULES_MODULES_VIEW_DEFAULT_TITLE="Module"


### PR DESCRIPTION
- originally deleted in https://github.com/joomla/joomla-cms/pull/19285
- deleted in com_modules #1957

### Zusammenfassung der Änderungen

remove string (sync core)

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

deleted