### PR TITLE
[4.1] Viertelgeviertstrich vs. Halbgeviertstrich (Erweiterungsnamen)

### DIFF
--- a/administrator/language/de-DE/plg_editors-xtd_image.ini
+++ b/administrator/language/de-DE/plg_editors-xtd_image.ini
@@ -4,7 +4,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_EDITORS-XTD_IMAGE="Schaltfläche – Medien"
+PLG_EDITORS-XTD_IMAGE="Schaltfläche - Medien"
 PLG_IMAGE_BUTTON_IMAGE="Medien"
 PLG_IMAGE_BUTTON_INSERT="Medien einfügen"
 PLG_IMAGE_XML_DESCRIPTION="Zeigt eine Schaltfläche zum Einfügen von Medien in einen Editorbereich an. Blendet ein Popup-Fenster ein, in dem die Eigenschaften einer Mediendatei konfiguriert und neue hochgeladen werden können."

--- a/administrator/language/de-DE/plg_editors-xtd_image.sys.ini
+++ b/administrator/language/de-DE/plg_editors-xtd_image.sys.ini
@@ -4,5 +4,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_EDITORS-XTD_IMAGE="Schaltfläche – Medien"
+PLG_EDITORS-XTD_IMAGE="Schaltfläche - Medien"
 PLG_IMAGE_XML_DESCRIPTION="Zeigt eine Schaltfläche zum Einfügen von Medien in einen Editorbereich an. Blendet ein Popup-Fenster ein, in dem die Eigenschaften einer Mediendatei konfiguriert und neue hochgeladen werden können."

--- a/administrator/language/de-DE/plg_fields_subform.sys.ini
+++ b/administrator/language/de-DE/plg_fields_subform.sys.ini
@@ -4,5 +4,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_SUBFORM="Felder – Subform"
+PLG_FIELDS_SUBFORM="Felder - Subform"
 PLG_FIELDS_SUBFORM_XML_DESCRIPTION="Dieses Plugin ermöglicht das Erstellen neuer Felder vom Typ „subform“, die mindestens ein Feld enthalten, in allen Erweiterungen, in denen benutzerdefinierte Felder möglich sind."

--- a/administrator/language/de-DE/plg_workflow_featuring.ini
+++ b/administrator/language/de-DE/plg_workflow_featuring.ini
@@ -4,7 +4,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_WORKFLOW_FEATURING="Workflow – Haupt-Eigenschaft"
+PLG_WORKFLOW_FEATURING="Workflow - Haupt-Eigenschaft"
 PLG_WORKFLOW_FEATURING_CHANGE_STATE_NOT_ALLOWED="Es ist nicht erlaubt, die Haupt-Status dieses Eintrags zu ändern. Bitte einen Workflow-Übergang verwenden."
 PLG_WORKFLOW_FEATURING_FEATURED="Haupteintrag: %s"
 PLG_WORKFLOW_FEATURING_TRANSITION_ACTIONS_FEATURING_DESC="Die Phase des Eintrags definieren, der bei der Ausführung dieses Übergangs gesetzt werden soll"

--- a/administrator/language/de-DE/plg_workflow_featuring.sys.ini
+++ b/administrator/language/de-DE/plg_workflow_featuring.sys.ini
@@ -4,5 +4,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_WORKFLOW_FEATURING="Workflow – Haupt-Eigenschaft"
+PLG_WORKFLOW_FEATURING="Workflow - Haupt-Eigenschaft"
 PLG_WORKFLOW_FEATURING_XML_DESCRIPTION="Fügt den Workflow-Übergängen von Einträgen Aktionen hinzu"

--- a/administrator/language/de-DE/plg_workflow_notification.ini
+++ b/administrator/language/de-DE/plg_workflow_notification.ini
@@ -6,7 +6,7 @@
 
 COM_WORKFLOW_BASIC_STAGE="Grundphase"
 COM_WORKFLOW_NOTIFICATION_FIELDSET_LABEL="Benachrichtigung"
-PLG_WORKFLOW_NOTIFICATION="Workflow – Benachrichtigung"
+PLG_WORKFLOW_NOTIFICATION="Workflow - Benachrichtigung"
 PLG_WORKFLOW_NOTIFICATION_ADDTEXT="Die Phase hat sich geändert"
 PLG_WORKFLOW_NOTIFICATION_ADDTEXT_DESC="Die Nachricht wird folgenden Inhalt haben: Titel [title], geändert von [user], neuer Status: [state]. Dieser Information kann noch eine eigene Mitteilung hinzufügt werden. Der Text kann mit Hilfe eines Sprachen-Overrides angepasst werden."
 PLG_WORKFLOW_NOTIFICATION_ADDTEXT_LABEL="Zusätzlicher Nachrichtentext"

--- a/administrator/language/de-DE/plg_workflow_notification.sys.ini
+++ b/administrator/language/de-DE/plg_workflow_notification.sys.ini
@@ -4,5 +4,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_WORKFLOW_NOTIFICATION="Workflow – Benachrichtigung"
+PLG_WORKFLOW_NOTIFICATION="Workflow - Benachrichtigung"
 PLG_WORKFLOW_NOTIFICATION_XML_DESCRIPTION="Sendet Benachrichtigungen für Übergänge im Veröffentlichungs-Workflow"

--- a/administrator/language/de-DE/plg_workflow_publishing.ini
+++ b/administrator/language/de-DE/plg_workflow_publishing.ini
@@ -4,7 +4,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_WORKFLOW_PUBLISHING="Workflow – Veröffentlichung"
+PLG_WORKFLOW_PUBLISHING="Workflow - Veröffentlichung"
 PLG_WORKFLOW_PUBLISHING_CHANGE_STATE_NOT_ALLOWED="Es ist nicht erlaubt, den Veröffentlichungsstatus dieses Eintrags zu ändern. Bitte einen Workflow-Übergang verwenden."
 PLG_WORKFLOW_PUBLISHING_PUBLISHED="Status: %s"
 PLG_WORKFLOW_PUBLISHING_TRANSITION_ACTIONS_PUBLISHING_DESC="Die Phase festlegen, auf die ein Eintrag gesetzt werden soll, wenn dieser Übergang ausgeführt wird"


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Halbgeviertstrich durch Viertelgeviertstrich ersetzt (einheitlich und gleich wie Core)

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

backend