### PR TITLE
[4.x] Fix syntax error in com_installer.ini

### DIFF
--- a/administrator/language/de-DE/com_installer.ini
+++ b/administrator/language/de-DE/com_installer.ini
@@ -1,4 +1,4 @@
- – ; Joomla! German Translation
+; Joomla! German Translation
 ; (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
 ; (C) Translation 2008 - 2022 J!German <https://www.jgerman.de>
 ; License GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Fix syntax error caused by #2532.
![image](https://user-images.githubusercontent.com/66922325/180048395-44cfd9a8-9e83-4410-828f-70b0e52d5233.png)


### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

backend
