### PR TITLE
[4.x] Format Erstelldatum (installation)

### DIFF
--- a/build/bump.php
+++ b/build/bump.php
@@ -163,7 +163,7 @@ $version = array(
 	'reltz'           => 'GMT',
 	'credate'         => date('Y-m-d'),
 	'credate_de'      => date('d.m.Y'),
-	'install_credate' => date('F Y'),
+	'install_credate' => date('Y-m'),
 	'install_version' => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
 );
 


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Format von Erstelldatum an `admin`, `api` und `site` angepasst.

Wird auch so im Core verwendet:
https://github.com/joomla/joomla-cms/blob/fa69fe61ec406b083baed9e71af1a071052e380a/language/en-GB/langmetadata.xml#L5
