### PR TITLE
[4.3] consistent encoding in xml files

### DIFF
--- a/administrator/language/de-DE/install.xml
+++ b/administrator/language/de-DE/install.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension client="administrator" type="language" method="upgrade">
 	<name>German (DE)</name>
 	<tag>de-DE</tag>

--- a/administrator/language/de-DE/langmetadata.xml
+++ b/administrator/language/de-DE/langmetadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metafile client="administrator">
 	<name>German (Germany)</name>
 	<tag>de-DE</tag>

--- a/api/language/de-DE/install.xml
+++ b/api/language/de-DE/install.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension client="api" type="language" method="upgrade">
 	<name>German (DE)</name>
 	<tag>de-DE</tag>

--- a/api/language/de-DE/langmetadata.xml
+++ b/api/language/de-DE/langmetadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metafile client="api">
 	<name>German (Germany)</name>
 	<tag>de-DE</tag>

--- a/installation/language/de-DE/langmetadata.xml
+++ b/installation/language/de-DE/langmetadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metafile client="installation">
 	<name>German (Germany)</name>
 	<version>4.3.0</version>

--- a/installation/localise.xml
+++ b/installation/localise.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <localise client="installation" >
 	<forceLang>de-DE</forceLang>
 	<helpurl></helpurl>

--- a/language/de-DE/install.xml
+++ b/language/de-DE/install.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension client="site" type="language" method="upgrade">
 	<name>German (DE)</name>
 	<tag>de-DE</tag>

--- a/language/de-DE/langmetadata.xml
+++ b/language/de-DE/langmetadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metafile client="site">
 	<name>German (Germany)</name>
 	<tag>de-DE</tag>

--- a/pkg_de-DE.xml
+++ b/pkg_de-DE.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="package" method="upgrade">
 	<name>German (Germany) Language Pack</name>
 	<packagename>de-DE</packagename>


### PR DESCRIPTION
see joomla/joomla-cms#39951

### Zusammenfassung der Änderungen

change encoding form `utf-8` to `UTF-8` (uppercase) in xml files

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

code review
