### PR TITLE
[5.0] Smart Search: Index custom fields

### DIFF
--- a/administrator/language/de-DE/com_fields.ini
+++ b/administrator/language/de-DE/com_fields.ini
@@ -101,6 +101,7 @@ COM_FIELDS_NO_FIELDS_TO_CREATE_SUBFORM_FIELD_WARNING="Es ist notwendig Standardf
 COM_FIELDS_ONLY_USE_IN_SUBFORM="- In Subform benutzen -"
 COM_FIELDS_ONLY_USE_IN_SUBFORM_ANY="In allen Forms"
 COM_FIELDS_ONLY_USE_IN_SUBFORM_SUBFORM="Nur in Subforms"
+COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING="Please note, that your changes in the Custom Fields Manager might require you to rebuild the index of Smart Search."
 COM_FIELDS_SYSTEM_PLUGIN_NOT_ENABLED="Das <a href='%s'>System – Felder</a>-Plugin ist deaktiviert. Eigene Felder werden solange nicht angezeigt, bis dieses Plugin aktiviert wurde."
 COM_FIELDS_VIEW_FIELD_ADD_TITLE="%s: Neues Feld"
 COM_FIELDS_VIEW_FIELD_EDIT_TITLE="%s: Feld bearbeiten"

--- a/administrator/language/de-DE/com_fields.ini
+++ b/administrator/language/de-DE/com_fields.ini
@@ -101,7 +101,7 @@ COM_FIELDS_NO_FIELDS_TO_CREATE_SUBFORM_FIELD_WARNING="Es ist notwendig Standardf
 COM_FIELDS_ONLY_USE_IN_SUBFORM="- In Subform benutzen -"
 COM_FIELDS_ONLY_USE_IN_SUBFORM_ANY="In allen Forms"
 COM_FIELDS_ONLY_USE_IN_SUBFORM_SUBFORM="Nur in Subforms"
-COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING="Please note, that your changes in the Custom Fields Manager might require you to rebuild the index of Smart Search."
+COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING="Bitte beachten, dass Änderungen an eigenen Feldern möglicherweise die Neuerstellung des Suchindexes erfordern."
 COM_FIELDS_SYSTEM_PLUGIN_NOT_ENABLED="Das <a href='%s'>System – Felder</a>-Plugin ist deaktiviert. Eigene Felder werden solange nicht angezeigt, bis dieses Plugin aktiviert wurde."
 COM_FIELDS_VIEW_FIELD_ADD_TITLE="%s: Neues Feld"
 COM_FIELDS_VIEW_FIELD_EDIT_TITLE="%s: Feld bearbeiten"


### PR DESCRIPTION
Pull Request für Issue #2825 .

### Zusammenfassung der Änderungen

add string

_Info:_ Die übrigen Übersetzungen sind bereits seit 4.2.0v1 (#2464) enthalten und wurden, nicht wie im Core, beibehalten.

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

backend (com_fields/field/edit)
![image](https://github.com/joomlagerman/joomla/assets/66922325/9680b2f2-098e-4936-b8db-dfe1643427f8)

backend (com_fields/fields)
![image](https://github.com/joomlagerman/joomla/assets/66922325/704f850a-6990-4855-8735-6d0b82785163)
