### PR TITLE
[5.1] typo quotation marks

### DIFF
--- a/administrator/language/de-DE/plg_system_sef.ini
+++ b/administrator/language/de-DE/plg_system_sef.ini
@@ -6,7 +6,7 @@
 
 PLG_SEF_DOMAIN_DESCRIPTION="Wenn die Website über mehrere Domains aufgerufen werden kann, so wird hier nur die übliche und vom Ersteller gewünschte Domain eingetragen."
 PLG_SEF_DOMAIN_LABEL="Website-Domain"
-PLG_SEF_INDEXPHP_DESCRIPTION="Diese Option ermöglicht einen strengeren Umgang mit „index.php' in URLs, wenn „URL-Rewrite nutzen“ in der Globalen Konfiguration aktiviert ist. Sie entfernt „index.php“, wenn eine URL sie noch enthält, und leitet eingehende Anfragen mit „index.php“ auf die Version ohne „index.php“ um."
+PLG_SEF_INDEXPHP_DESCRIPTION="Diese Option ermöglicht einen strengeren Umgang mit „index.php“ in URLs, wenn „URL-Rewrite nutzen“ in der Globalen Konfiguration aktiviert ist. Sie entfernt „index.php“, wenn eine URL sie noch enthält, und leitet eingehende Anfragen mit „index.php“ auf die Version ohne „index.php“ um."
 PLG_SEF_INDEXPHP_LABEL="Strenge Handhabung von index.php"
 PLG_SEF_TRAILINGSLASH_DESCRIPTION="Zwingt Joomla, nur URLs mit oder ohne nachgestellten Schrägstrich (trailing slash) zu verwenden. Wenn dies eingestellt ist, wird die richtige URL mit Weiterleitungen erzwungen. Diese Option wird nur angewendet, wenn „Dateiendung an URL anfügen“ deaktiviert ist."
 PLG_SEF_TRAILINGSLASH_LABEL="Nachgestellter Schrägstrich für URLs"


### PR DESCRIPTION
### Zusammenfassung der Änderungen

fix quotation marks
![image](https://github.com/joomlagerman/joomla/assets/66922325/741e3907-1a1a-4cda-a83a-c3a64a095368)

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

backend (com_plugins/plugin/edit)
![image](https://github.com/joomlagerman/joomla/assets/66922325/1493f8b8-bc2b-430e-9537-191cbe8a5321)
