### PR TITLE
[5.2] [Guided tours] Add missing auto start parameter in the user interface of tours #3224

### DIFF
--- a/administrator/language/de-DE/com_guidedtours.ini
+++ b/administrator/language/de-DE/com_guidedtours.ini
@@ -6,7 +6,7 @@
 
 COM_GUIDEDTOURS="Geführte Touren"
 COM_GUIDEDTOURS_AUTOSTART_DESC="Startet die Tour automatisch, wenn ein Benutzer den Kontext erreicht, in dem die Tour angezeigt werden soll."
-COM_GUIDEDTOURS_AUTOSTART_LABEL="Touren automatisch starten"
+COM_GUIDEDTOURS_AUTOSTART_LABEL="Tour automatisch starten"
 COM_GUIDEDTOURS_CONFIGURATION="Geführte Touren: Optionen"
 COM_GUIDEDTOURS_DESCRIPTION="Beschreibung"
 COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION="Beschreibung (%s)"

--- a/administrator/language/de-DE/com_guidedtours.ini
+++ b/administrator/language/de-DE/com_guidedtours.ini
@@ -5,6 +5,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_GUIDEDTOURS="Geführte Touren"
+COM_GUIDEDTOURS_AUTOSTART_DESC="Startet die Tour automatisch, wenn ein Benutzer den Kontext erreicht, in dem die Tour angezeigt werden soll."
+COM_GUIDEDTOURS_AUTOSTART_LABEL="Touren automatisch starten"
 COM_GUIDEDTOURS_CONFIGURATION="Geführte Touren: Optionen"
 COM_GUIDEDTOURS_DESCRIPTION="Beschreibung"
 COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION="Beschreibung (%s)"


### PR DESCRIPTION
Pull Request für Issue [#3224](https://github.com/joomlagerman/joomla/issues/3224)

### Zusammenfassung der Änderungen

[5.2] [Guided tours] Add missing auto start parameter in the user interface of tours #3224

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden

Backend ->Guided tours -> Tour settting
