### PR TITLE
[6.0] Deprecate unused phpmailer language string

### DIFF
--- a/administrator/language/de-DE/joomla.ini
+++ b/administrator/language/de-DE/joomla.ini
@@ -927,6 +927,7 @@ PHPMAILER_RECIPIENTS_FAILED="SMTP-Fehler! Die folgenden Empfänger sind nicht ko
 PHPMAILER_SIGNING_ERROR="Zeichenkodierungsfehler: "
 PHPMAILER_SMTP_CONNECT_FAILED="SMTP-Verbindung <strong>fehlgeschlagen</strong>"
 PHPMAILER_SMTP_ERROR="SMTP-Server-Fehler: "
+; Deprecated, will be removed with 7.0
 PHPMAILER_TLS="TLS konnte nicht gestartet werden"
 PHPMAILER_VARIABLE_SET="Die Variable kann nicht gesetzt oder zurückgesetzt werden: "
 

--- a/api/language/de-DE/joomla.ini
+++ b/api/language/de-DE/joomla.ini
@@ -916,6 +916,7 @@ PHPMAILER_RECIPIENTS_FAILED="SMTP-Fehler! Die folgenden Empfänger sind nicht ko
 PHPMAILER_SIGNING_ERROR="Zeichenkodierungsfehler: "
 PHPMAILER_SMTP_CONNECT_FAILED="SMTP-Verbindung <strong>fehlgeschlagen</strong>"
 PHPMAILER_SMTP_ERROR="SMTP-Server-Fehler: "
+; Deprecated, will be removed with 7.0
 PHPMAILER_TLS="TLS konnte nicht gestartet werden"
 PHPMAILER_VARIABLE_SET="Die Variable kann nicht gesetzt oder zurückgesetzt werden: "
 

--- a/language/de-DE/joomla.ini
+++ b/language/de-DE/joomla.ini
@@ -496,6 +496,7 @@ PHPMAILER_RECIPIENTS_FAILED="SMTP-Fehler! Die folgenden Empfänger sind nicht ko
 PHPMAILER_SIGNING_ERROR="Zeichenkodierungsfehler: "
 PHPMAILER_SMTP_CONNECT_FAILED="SMTP-Verbindung <strong>fehlgeschlagen</strong>"
 PHPMAILER_SMTP_ERROR="SMTP-Server-Fehler: "
+; Deprecated, will be removed with 7.0
 PHPMAILER_TLS="TLS konnte nicht gestartet werden"
 PHPMAILER_VARIABLE_SET="Die Variable kann nicht gesetzt oder zurückgesetzt werden: "
 


### PR DESCRIPTION
Pull Request für Issue #3643

### Zusammenfassung der Änderungen

add Deprecation note

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
- [x] Backend
- [x] Frontend
- [x] API
- [ ] Installation
- [ ] Sonstiges (bitte beschreiben) ________________________
