### PR TITLE
[6.x] Fix wrong paths for old guided tours files in script.php

### DIFF
--- a/script.php
+++ b/script.php
@@ -428,12 +428,12 @@ class Pkg_deDEInstallerScript extends InstallerScript
             '/administrator/language/de-DE/plg_captcha_recaptcha_invisible.sys.ini',
             '/administrator/language/de-DE/plg_behaviour_compat.ini',
             '/administrator/language/de-DE/plg_behaviour_compat.sys.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2_steps.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3_steps.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4.ini',
-            'administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4_steps.ini'
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2.ini',
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2_steps.ini',
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3.ini',
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3_steps.ini',
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4.ini',
+            '/administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4_steps.ini'
         ];
     }
 


### PR DESCRIPTION
Pull Request für Issue #

### Zusammenfassung der Änderungen

Fehlende führende Slashes in zu löschenden, alten Guided-Tours-Sprachdateien in script.php hinzugefügt.

Am einfachsten zu testen mit einer Open-Basedir-Restriktion in der php.ini und Loggen von Fehlern.

Derzeit beim Update des deutschen 6.0-er Sprachpakets:
```
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_2_steps.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_3_steps.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
PHP Warning:  is_file(): open_basedir restriction in effect. File(/htdocs/test4administrator/language/de-DE/guidedtours.joomla_whatsnew_5_4_steps.ini) is not within the allowed path(s): (/htdocs/test4/:/htdocs/sitemedia/:/htdocs/shariff-backend-php/:/htdocs/shariff-backend-php-test/:/usr/lib/php8.4/) in /htdocs/test4/libraries/src/Installer/InstallerScript.php on line 325
```
Man beachte das `/test4administrator/` im Pfad. Joomla-Root ist hier (leicht anonymisiert `/htdocs/test4`).

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
- [ ] Backend
- [ ] Frontend
- [ ] API
- [ ] Installation
- [X] Sonstiges (bitte beschreiben) s.o.
