### PR TITLE
[5.4] alpha sort strings JLIB_LANGUAGE_ERROR_CANNOT_LOAD_

### DIFF
--- a/administrator/language/de-DE/lib_joomla.ini
+++ b/administrator/language/de-DE/lib_joomla.ini
@@ -769,8 +769,8 @@ JLIB_JS_AJAX_ERROR_OTHER="Beim Abrufen von JSON-Daten wurde ein HTTP-Statuscode 
 JLIB_JS_AJAX_ERROR_PARSE="Ein Parsing-Fehler trat bei der Verarbeitung der folgenden JSON-Daten auf:<br><code style='color:inherit;white-space:pre-wrap;padding:0;margin:0;border:0;background:inherit;'>%s</code>"
 JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Daten auf."
 
-JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Die Sprachen-XML für %s von %s konnte nicht geladen werden."
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA="Die Metadaten %s von %s konnten nicht geladen werden."
+JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Die Sprachen-XML für %s von %s konnte nicht geladen werden."
 
 JLIB_LOGIN_AUTHORISATION="Der Zugang wurde autorisiert."
 JLIB_LOGIN_DENIED="Der Zugang wurde verweigert."

--- a/language/de-DE/lib_joomla.ini
+++ b/language/de-DE/lib_joomla.ini
@@ -739,8 +739,8 @@ JLIB_JS_AJAX_ERROR_OTHER="Beim Abrufen von JSON-Daten wurde ein HTTP-Statuscode 
 JLIB_JS_AJAX_ERROR_PARSE="Ein Parsing-Fehler trat bei der Verarbeitung der folgenden JSON-Daten auf:<br><code style='color:inherit;white-space:pre-wrap;padding:0;margin:0;border:0;background:inherit;'>%s</code>"
 JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Daten auf."
 
-JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Die Sprachen-XML für %s von %s konnte nicht geladen werden."
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA="Die Metadaten %s von %s konnten nicht geladen werden."
+JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Die Sprachen-XML für %s von %s konnte nicht geladen werden."
 
 JLIB_LOGIN_AUTHORISATION="Der Zugang wurde autorisiert."
 JLIB_LOGIN_DENIED="Der Zugang wurde verweigert."


### PR DESCRIPTION
### Zusammenfassung der Änderungen

Während der Bearbeitung von #3679 aufgefallen.
Dieser PR sortiert die beiden Strings in 5.4

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
- [x] Backend
- [x] Frontend
- [ ] API
- [ ] Installation
- [ ] Sonstiges (bitte beschreiben) ________________________
