### PR TITLE
Sprache konfigurieren Button während der Installation neuer Sprachen

### DIFF
--- a/installation/language/de-DE/joomla.ini
+++ b/installation/language/de-DE/joomla.ini
@@ -166,7 +166,7 @@ INSTL_DEFAULTLANGUAGE_DESC_FRONTEND="Joomla hat folgende Sprachen installiert. B
 INSTL_DEFAULTLANGUAGE_FRONTEND="Standard-Sprache: Website"
 INSTL_DEFAULTLANGUAGE_FRONTEND_COULDNT_SET_DEFAULT="Joomla war es nicht möglich die Sprache als Standard festzulegen. Englisch wird daher als Standard-Sprache für die WEBSITE (Frontend) verwendet."
 INSTL_DEFAULTLANGUAGE_FRONTEND_SET_DEFAULT="Die Sprache mit dem Sprach-Tag „%s“ wurde zur Standard-Sprache für die WEBSITE festgelegt."
-INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Standardsprache konfigurieren"
+INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Standardsprache setzen"
 INSTL_DEFAULTLANGUAGE_TRY_LATER="Weitere Sprachen können auch noch später in der Administration von Joomla installiert werden."
 
 INSTL_DEFAULTLANGUAGE_NATIVE_LANGUAGE_NAME="Deutsch (Deutschland)" ; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example Spanish will be Español

--- a/installation/language/de-DE/joomla.ini
+++ b/installation/language/de-DE/joomla.ini
@@ -166,7 +166,7 @@ INSTL_DEFAULTLANGUAGE_DESC_FRONTEND="Joomla hat folgende Sprachen installiert. B
 INSTL_DEFAULTLANGUAGE_FRONTEND="Standard-Sprache: Website"
 INSTL_DEFAULTLANGUAGE_FRONTEND_COULDNT_SET_DEFAULT="Joomla war es nicht möglich die Sprache als Standard festzulegen. Englisch wird daher als Standard-Sprache für die WEBSITE (Frontend) verwendet."
 INSTL_DEFAULTLANGUAGE_FRONTEND_SET_DEFAULT="Die Sprache mit dem Sprach-Tag „%s“ wurde zur Standard-Sprache für die WEBSITE festgelegt."
-INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Standardsprache setzen"
+INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Standardsprache festlegen"
 INSTL_DEFAULTLANGUAGE_TRY_LATER="Weitere Sprachen können auch noch später in der Administration von Joomla installiert werden."
 
 INSTL_DEFAULTLANGUAGE_NATIVE_LANGUAGE_NAME="Deutsch (Deutschland)" ; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example Spanish will be Español


### PR DESCRIPTION
Pull Request für Issue #

### Zusammenfassung der Änderungen

Wenn man im letzten Installationsschritt von Joomla! eine oder mehreren Sprachen zusätzlich installiert hat, kann man die Standardsprache festlegen.

<img width="671" height="471" alt="image" src="https://github.com/user-attachments/assets/34216394-4d6d-4831-ab93-6554e4a06ca7" />

"Konfigurieren" ist nicht das Wort, was ich im Button erwarten würde sondern setzen/festlegen/....

### Wo wird der Sprachstring angezeigt / Wie kann getestet werden
- [ ] Backend
- [ ] Frontend
- [ ] API
- [x] Installation
- [ ] Sonstiges (bitte beschreiben) ________________________
